### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Use the `model/predict` endpoint to load a test image (you can use one of the te
 You can also test it on the command line, for example:
 
 ```
-$ curl -F "file=@assets/test_image.jpg" -XPOST http://localhost:5000/model/predict
+$ curl -F "file=@assets/Pilots.jpg" -XPOST http://localhost:5000/model/predict
 ```
 
 You should see a JSON response like that below:


### PR DESCRIPTION
There is not `test_image.jpg` under `asset` directory.
It is understandable but `Pilots.jpg` is more suitable for users.