### PR TITLE
Avoid creating a Docker layer containing the compressed model file.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,8 @@ RUN apt-get update && apt-get install libgtk2.0 -y && rm -rf /var/lib/apt/lists/
 RUN apt-get update && apt-get install -y gcc && apt-get install -y swig \
                    && apt-get install --reinstall -y build-essential && rm -rf /var/lib/apt/lists/*
 
-RUN wget -nv --show-progress --progress=bar:force:noscroll ${model_bucket}/${model_file} --output-document=/workspace/assets/${model_file}
-RUN tar -x -C assets/ -f assets/${model_file} -v && rm assets/${model_file}
+RUN wget -nv --show-progress --progress=bar:force:noscroll ${model_bucket}/${model_file} --output-document=/workspace/assets/${model_file} && \
+  tar -x -C assets/ -f assets/${model_file} -v && rm assets/${model_file}
 
 COPY requirements.txt /workspace
 RUN pip install -r requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM codait/max-base:v1.1.0
+FROM codait/max-base:v1.1.1
 
 # Fill in these with a link to the bucket containing the model and the model file name
 ARG model_bucket=http://max-assets.s3-api.us-geo.objectstorage.softlayer.net/human-pose-estimator/1.0


### PR DESCRIPTION
Download and delete the compressed model file in the same layer to avoid an (often oversized) additional Docker layer.