### PR TITLE
Undefined name: Error --> ValueError

### DIFF
--- a/core/model.py
+++ b/core/model.py
@@ -39,7 +39,7 @@ class ModelWrapper(MAXModelWrapper):
     def _read_image(self, image_data):
         try:
             image = Image.open(io.BytesIO(image_data))
-            if image.mode is not 'RGB':
+            if image.mode != 'RGB':
                image = image.convert('RGB')
             # Convert RGB to BGR for OpenCV.
             image = np.array(image)[:, :, ::-1]

--- a/core/tf_pose/slidingwindow/SlidingWindow.py
+++ b/core/tf_pose/slidingwindow/SlidingWindow.py
@@ -75,7 +75,7 @@ class SlidingWindow(object):
 				)
 			
 		else:
-			raise Error('Unsupported order of dimensions: ' + str(self.dimOrder))
+			raise ValueError('Unsupported order of dimensions: ' + str(self.dimOrder))
 		
 	def __str__(self):
 		return '(' + str(self.x) + ',' + str(self.y) + ',' + str(self.w) + ',' + str(self.h) + ')'


### PR DESCRIPTION
__Error__ is an undefined name in this context so use Python builtin __ValueError__ instead.  An alternative would be to use the builtin __Exception__ which is the Python base error.

[flake8](http://flake8.pycqa.org) testing of https://github.com/IBM/MAX-Human-Pose-Estimator on Python 3.7.1

$ __flake8 . --count --select=E9,F63,F72,F82 --show-source --statistics__
```
./core/model.py:42:16: F632 use ==/!= to compare str, bytes, and int literals
            if image.mode is not 'RGB':
               ^
./core/tf_pose/slidingwindow/SlidingWindow.py:78:10: F821 undefined name 'Error'
			raise Error('Unsupported order of dimensions: ' + str(self.dimOrder))
         ^
1     F632 use ==/!= to compare str, bytes, and int literals
1     F821 undefined name 'Error'
2
```
__E901,E999,F821,F822,F823__ are the "_showstopper_" [flake8](http://flake8.pycqa.org) issues that can halt the runtime with a SyntaxError, NameError, etc. These 5 are different from most other flake8 issues which are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree
